### PR TITLE
fix wrong return types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,8 @@ export type WebhookOptions = {
 
 export class Webhook {
   constructor(options: string | WebhookOptions);
-  setUsername(username: string): void;
-  setAvatar(avatar: string): void;
+  setUsername(username: string): this;
+  setAvatar(avatar: string): this;
   send(message: MessageBuilder | string): Promise<void>;
 }
 


### PR DESCRIPTION
Hi there!
Nice library you got here, thanks for making it, it has made my life a lot easier.

I took a look at your code and found `Webhook.prototype.setUsername` and `Webhook.prototype.setAvatar` return `this` in the code, but this is not reflected in your type declarations.
I changed this in this pull request.

Do note I didn't bump the version in `package.json`, you'll have to do that yourself before publishing these changes.

Have a nice day!